### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,7 +548,7 @@ mod test {
                 }
                 tick += 1;
             }
-            println!("0x{byte:.X}");
+            println!("0x{byte:X}");
             break;
         }
         let mut str = String::new();


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.